### PR TITLE
libzen cannot parse if-statements without semicolon.

### DIFF
--- a/src/zen/lang/ZenGrammar.java
+++ b/src/zen/lang/ZenGrammar.java
@@ -751,7 +751,7 @@ public class ZenGrammar {
 		if(!TokenContext.MatchToken(")")) {
 			while(!FuncNode.IsErrorNode()) {
 				FuncNode = TokenContext.AppendMatchedPattern(FuncNode, NameSpace, "$Param$", ZenParserConst.Required);
-				if(TokenContext.MatchToken(")")) {
+				if(TokenContext.MatchNodeToken(FuncNode,  NameSpace, ")", ZenParserConst.Optional | ZenParserConst.DisallowSkipIndent) == FuncNode) {
 					break;
 				}
 				FuncNode = TokenContext.MatchNodeToken(FuncNode,  NameSpace, ",", ZenParserConst.Required);

--- a/test/zen/bug003-if-statement-needs-semicolon.green
+++ b/test/zen/bug003-if-statement-needs-semicolon.green
@@ -1,0 +1,5 @@
+function f(n) {
+    if(n < 3) {
+        return 1;
+    }
+}


### PR DESCRIPTION
libzen cannot parse if-statements without semicolon.

```
$ cat test/zen/bug003-if-statement-needs-semicolon.green
function f(n) {
    if(n < 3) {
        return 1;
    }
}
```

```
$ java -jar libzen.jar test/zen/bug003-if-statement-needs-semicolon.green

...

function f(n :var) :var{
   ;
}
(error) (test/zen/bug003-if-statement-needs-semicolon.green:5) ; is expected; } is given
```
