### PR TITLE
Remove needless override

### DIFF
--- a/src/zen/codegen/clisp/CommonLispGenerator.java
+++ b/src/zen/codegen/clisp/CommonLispGenerator.java
@@ -100,10 +100,6 @@ public class CommonLispGenerator extends ZSourceGenerator {
 
 	}
 
-	@Override public void VisitGetNameNode(ZGetNameNode Node) {
-		this.CurrentBuilder.Append(Node.SourceToken.GetText());
-	}
-
 	@Override public void VisitSetNameNode(ZSetNameNode Node) {
 		this.CurrentBuilder.Append("(setq  " + this.NameLocalVariable(Node.GetName(), Node.VarIndex));
 		this.CurrentBuilder.Append(" ");


### PR DESCRIPTION
This makes `continue` test fail.

Now, I suppose all tests are passed.

```
% ZENCODE=cl bash test/testfiles.sh test/common build/test
[OK] G1_HelloWorld
[OK] G2_BinaryOperator
[OK] G2_Function
[OK] G2_Grouping
[OK] G3_FunctionNoReturn
[OK] G3_FunctionParameter
[OK] G3_If
[OK] G3_Let
[OK] G3_Prototype
[OK] G3_Throw
[OK] G3_Try
[OK] G3_Var
[OK] G3_While
[OK] G3_WhileBreak
[OK] G4_Boolean
[OK] G4_Float
[OK] G4_Int
[OK] G4_IntArray
[OK] G4_IntMap
[OK] G4_Null
[OK] G4_String
[OK] G4_ZeroDivided
[OK] G5_ApplyFunction
[OK] G5_LetFunction
[OK] G5_VarFunction
[OK] G6_Class
[OK] G6_Constructor
[OK] G6_DynamicBinding
[OK] G6_InstanceOf
[OK] G6_SubClass
[OK] G7_InferFunction
[OK] G8_Continue
[OK] G8_Math
[OK] G9_BinaryTrees
[OK] G9_BubbleSort
[OK] G9_Fibonacci
[OK] G9_MathSqrt
[OK] Gx_Closure
[OK] Gx_EvenOdd
[OK] Gx_Utf8String
% echo $?
0
```
